### PR TITLE
Rename library/class from `i2sinout.I2SInOut` to `pio_i2s.I2S`.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -2,8 +2,8 @@ Introduction
 ============
 
 
-.. image:: https://readthedocs.org/projects/circuitpython-i2sinout/badge/?version=latest
-    :target: https://circuitpython-i2sinout.readthedocs.io/
+.. image:: https://readthedocs.org/projects/circuitpython-pio-i2s/badge/?version=latest
+    :target: https://circuitpython-pio-i2s.readthedocs.io/
     :alt: Documentation Status
 
 
@@ -12,8 +12,8 @@ Introduction
     :alt: Discord
 
 
-.. image:: https://github.com/relic-se/CircuitPython_I2SInOut/workflows/Build%20CI/badge.svg
-    :target: https://github.com/relic-se/CircuitPython_I2SInOut/actions
+.. image:: https://github.com/relic-se/CircuitPython_PIO_I2S/workflows/Build%20CI/badge.svg
+    :target: https://github.com/relic-se/CircuitPython_PIO_I2S/actions
     :alt: Build Status
 
 
@@ -42,18 +42,18 @@ Installing from PyPI
    as a standard element. Stay tuned for PyPI availability!
 
 On supported GNU/Linux systems like the Raspberry Pi, you can install the driver locally `from
-PyPI <https://pypi.org/project/circuitpython-i2sinout/>`_.
+PyPI <https://pypi.org/project/circuitpython-pio-i2s/>`_.
 To install for current user:
 
 .. code-block:: shell
 
-    pip3 install circuitpython-i2sinout
+    pip3 install circuitpython-pio-i2s
 
 To install system-wide (this may be required in some cases):
 
 .. code-block:: shell
 
-    sudo pip3 install circuitpython-i2sinout
+    sudo pip3 install circuitpython-pio-i2s
 
 To install in a virtual environment in your current project:
 
@@ -62,7 +62,7 @@ To install in a virtual environment in your current project:
     mkdir project-name && cd project-name
     python3 -m venv .venv
     source .env/bin/activate
-    pip3 install circuitpython-i2sinout
+    pip3 install circuitpython-pio-i2s
 
 Installing to a Connected CircuitPython Device with Circup
 ==========================================================
@@ -79,7 +79,7 @@ following command to install:
 
 .. code-block:: shell
 
-    circup install i2sinout
+    circup install pio_i2s
 
 Or the following command to update an existing version:
 
@@ -93,14 +93,14 @@ Usage Example
 .. code-block:: python
 
     import board
-    import i2sinout
-    codec = i2sinout.I2SInOut(board.GP0, data_in=board.GP2, data_out=board.GP3)
+    import pio_i2s
+    codec = pio_i2s.I2S(board.GP0, data_in=board.GP2, data_out=board.GP3)
     while True:
         codec.write(codec.read(block=True))
 
 Documentation
 =============
-API documentation for this library can be found on `Read the Docs <https://circuitpython-i2sinout.readthedocs.io/>`_.
+API documentation for this library can be found on `Read the Docs <https://circuitpython-pio-i2s.readthedocs.io/>`_.
 
 For information on building library documentation, please check out
 `this guide <https://learn.adafruit.com/creating-and-sharing-a-circuitpython-library/sharing-our-docs-on-readthedocs#sphinx-5-1>`_.
@@ -109,5 +109,5 @@ Contributing
 ============
 
 Contributions are welcome! Please read our `Code of Conduct
-<https://github.com/relic-se/CircuitPython_I2SInOut/blob/HEAD/CODE_OF_CONDUCT.md>`_
+<https://github.com/relic-se/CircuitPython_PIO_I2S/blob/HEAD/CODE_OF_CONDUCT.md>`_
 before contributing to help this project stay welcoming.

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -4,5 +4,5 @@
 .. If your library file(s) are nested in a directory (e.g. /adafruit_foo/foo.py)
 .. use this format as the module name: "adafruit_foo.foo"
 
-.. automodule:: i2sinout
+.. automodule:: pio_i2s
     :members:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -43,7 +43,7 @@ source_suffix = ".rst"
 master_doc = "index"
 
 # General information about the project.
-project = "CircuitPython I2SInOut Library"
+project = "CircuitPython PIO I2S Library"
 creation_year = "2024"
 current_year = str(datetime.datetime.now().year)
 year_duration = (
@@ -141,8 +141,8 @@ latex_elements = {
 latex_documents = [
     (
         master_doc,
-        "CircuitPython_I2SInOut_Library.tex",
-        "CircuitPython I2SInOut Library Documentation",
+        "CircuitPython_PIO_I2S_Library.tex",
+        "CircuitPython PIO I2S Library Documentation",
         author,
         "manual",
     ),
@@ -155,8 +155,8 @@ latex_documents = [
 man_pages = [
     (
         master_doc,
-        "CircuitPython_I2SInOut_Library",
-        "CircuitPython I2SInOut Library Documentation",
+        "CircuitPython_PIO_I2S_Library",
+        "CircuitPython PIO I2S Library Documentation",
         [author],
         1,
     ),
@@ -170,10 +170,10 @@ man_pages = [
 texinfo_documents = [
     (
         master_doc,
-        "CircuitPython_I2SInOut_Library",
-        "CircuitPython I2SInOut Library Documentation",
+        "CircuitPython_PIO_I2S_Library",
+        "CircuitPython PIO I2S Library Documentation",
         author,
-        "CircuitPython_I2SInOut_Library",
+        "CircuitPython_PIO_I2S_Library",
         "One line description of project.",
         "Miscellaneous",
     ),

--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -3,6 +3,6 @@ Simple test
 
 Ensure your device works with this simple test.
 
-.. literalinclude:: ../examples/i2sinout_simpletest.py
-    :caption: examples/i2sinout_simpletest.py
+.. literalinclude:: ../examples/pio_i2s_simpletest.py
+    :caption: examples/pio_i2s_simpletest.py
     :linenos:

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -33,7 +33,7 @@ Table of Contents
 .. toctree::
     :caption: Other Links
 
-    Download from GitHub <https://github.com/relic-se/CircuitPython_I2SInOut/releases/latest>
+    Download from GitHub <https://github.com/relic-se/CircuitPython_PIO_I2S/releases/latest>
     Download Library Bundle <https://circuitpython.org/libraries>
     CircuitPython Reference Documentation <https://docs.circuitpython.org>
     CircuitPython Support Forum <https://forums.adafruit.com/viewforum.php?f=60>

--- a/examples/pio_i2s_effect.py
+++ b/examples/pio_i2s_effect.py
@@ -10,7 +10,7 @@ import audiomixer
 import board
 import ulab.numpy as np
 
-import i2sinout
+import pio_i2s
 
 BUFFER_SIZE = 1024
 
@@ -21,7 +21,7 @@ properties = {
     "samples_signed": True,
 }
 
-input = i2sinout.I2SInOut(
+input = pio_i2s.I2S(
     peripheral=True,  # Share clock signals with I2SOut
     data_in=board.GP0,
     bit_clock=board.GP1,
@@ -44,7 +44,7 @@ mixer = audiomixer.Mixer(
     **properties,
 )
 
-# Currently unable to get buffer from audio sample objects to feed into I2SInOut
+# Currently unable to get buffer from audio sample objects to feed into I2S
 # Must use a separate `audiosample.I2SOut` object, and connect bit_clock and word_select together
 output = audiobusio.I2SOut(
     bit_clock=board.GP3,

--- a/examples/pio_i2s_input.py
+++ b/examples/pio_i2s_input.py
@@ -5,9 +5,9 @@
 import board
 import ulab.numpy as np
 
-import i2sinout
+import pio_i2s
 
-codec = i2sinout.I2SInOut(
+codec = pio_i2s.I2S(
     bit_clock=board.GP0,  # word select is GP1
     data_in=board.GP2,
     channel_count=1,

--- a/examples/pio_i2s_output.py
+++ b/examples/pio_i2s_output.py
@@ -8,13 +8,13 @@ import math
 
 import board
 
-import i2sinout
+import pio_i2s
 
 CHANNEL_COUNT = 2
 SAMPLE_RATE = 22050
 LENGTH = SAMPLE_RATE // 440
 
-codec = i2sinout.I2SInOut(
+codec = pio_i2s.I2S(
     bit_clock=board.GP0,  # word select is GP1
     data_out=board.GP3,
     channel_count=CHANNEL_COUNT,

--- a/examples/pio_i2s_peripheral.py
+++ b/examples/pio_i2s_peripheral.py
@@ -5,12 +5,12 @@
 import board
 import ulab.numpy as np
 
-import i2sinout
+import pio_i2s
 
-codec = i2sinout.I2SInOut(
-    bit_clock=board.GP0,
-    word_select=board.GP1,  # does not need to be sequential in peripheral mode
-    data_in=board.GP2,
+codec = pio_i2s.I2S(
+    bit_clock=board.GP1,
+    word_select=board.GP2,  # does not need to be sequential in peripheral mode
+    data_in=board.GP0,  # must come before bit_clock
     channel_count=1,
     sample_rate=22050,
     bits_per_sample=16,

--- a/examples/pio_i2s_record.py
+++ b/examples/pio_i2s_record.py
@@ -12,12 +12,12 @@ import os
 import adafruit_wave
 import board
 
-import i2sinout
+import pio_i2s
 
 PATH = "/test.wav"
 LENGTH = 3000  # ms
 
-mic = i2sinout.I2SInOut(
+mic = pio_i2s.I2S(
     bit_clock=board.GP0,  # word select is GP1
     data_in=board.GP2,
     channel_count=1,

--- a/examples/pio_i2s_simpletest.py
+++ b/examples/pio_i2s_simpletest.py
@@ -5,9 +5,9 @@
 
 import board
 
-import i2sinout
+import pio_i2s
 
-codec = i2sinout.I2SInOut(
+codec = pio_i2s.I2S(
     bit_clock=board.GP0,  # word select is GP1
     data_out=board.GP2,
     data_in=board.GP3,

--- a/pio_i2s.py
+++ b/pio_i2s.py
@@ -3,7 +3,7 @@
 #
 # SPDX-License-Identifier: MIT
 """
-`i2sinout`
+`pio_i2s`
 ================================================================================
 
 Bidirectional I2S audio communication using PIO.
@@ -24,7 +24,7 @@ Implementation Notes
 # imports
 
 __version__ = "0.0.0+auto.0"
-__repo__ = "https://github.com/relic-se/CircuitPython_I2SInOut.git"
+__repo__ = "https://github.com/relic-se/CircuitPython_PIO_I2S.git"
 
 import array
 
@@ -45,7 +45,7 @@ def _get_gpio_index(pin: microcontroller.Pin) -> int:
     return None
 
 
-class I2SInOut:
+class I2S:
     """Communicate with external audio devices using I2S protocol.
 
     :param bit_clock: The bit clock (or serial clock) pin.
@@ -127,7 +127,7 @@ class I2SInOut:
 
         if not peripheral:
             pioasm = f"""
-.program i2sinout
+.program i2s_controller
 .side_set 2
     nop                         side 0b{1 if left_justified else 0}1
     set x {bits_per_sample-2}   side 0b{1 if left_justified else 0}1
@@ -150,7 +150,7 @@ right_bit:
             word_select_gpio = _get_gpio_index(word_select) if word_select else bit_clock_gpio + 1
             if not left_justified:
                 pioasm = f"""
-.program i2sinout
+.program i2s_peripheral
 .side_set 2
     wait 1 gpio {word_select_gpio}
     wait 1 gpio {bit_clock_gpio}
@@ -184,7 +184,7 @@ right_bit:
 """
             else:
                 pioasm = f"""
-.program i2sinout
+.program i2s_peripheral_left_justified
 .side_set 2
     wait 1 gpio {word_select_gpio}
     wait 1 gpio {bit_clock_gpio}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,20 +11,20 @@ requires = [
 ]
 
 [project]
-name = "circuitpython-i2sinout"
+name = "circuitpython-pio-i2s"
 description = "Bidirectional I2S audio communication using PIO."
 version = "0.0.0+auto.0"
 readme = "README.rst"
 authors = [
     {name = "Cooper Dalrymple", email = "me@dcdalrymple.com"}
 ]
-urls = {Homepage = "https://github.com/relic-se/CircuitPython_I2SInOut"}
+urls = {Homepage = "https://github.com/relic-se/CircuitPython_PIO_I2S"}
 keywords = [
     "adafruit",
     "blinka",
     "circuitpython",
     "micropython",
-    "i2sinout",
+    "pio",
     "i2s",
     "audio",
     "codec",
@@ -41,7 +41,7 @@ classifiers = [
 dynamic = ["dependencies", "optional-dependencies"]
 
 [tool.setuptools]
-py-modules = ["i2sinout"]
+py-modules = ["pio_i2s"]
 
 [tool.setuptools.dynamic]
 dependencies = {file = ["requirements.txt"]}


### PR DESCRIPTION
As proposed within bundle PR: https://github.com/adafruit/CircuitPython_Community_Bundle/pull/227.